### PR TITLE
[FIXES] Scrot image overwrite added

### DIFF
--- a/v3lock
+++ b/v3lock
@@ -2,7 +2,7 @@
 
 overlay=/usr/share/pixmaps/lockoverlay.png
 
-scrot /tmp/currentworkspace.png
+scrot -o /tmp/currentworkspace.png
 convert /tmp/currentworkspace.png -blur 0x5 /tmp/currentworkspaceblur.png
 composite -gravity southeast $overlay /tmp/currentworkspaceblur.png /tmp/lockbackground.png
 i3lock -i /tmp/lockbackground.png


### PR DESCRIPTION
- Added -o flag to overwrite the image with scrot (otherwise it will just create it as copy image.png, image_000.png, image_001.png etc.)
